### PR TITLE
add the coverage result to the comment image alt text 

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Message.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Message.java
@@ -36,7 +36,7 @@ class Message {
     }
 
     public String forComment(final String buildUrl, final String jenkinsUrl) {
-        return "[![Coverage](" + jenkinsUrl + "/coverage-status-icon/" +
+        return "[![" + forIcon() +"](" + jenkinsUrl + "/coverage-status-icon/" +
                 "?coverage=" + coverage +
                 "&masterCoverage=" + masterCoverage +
                 ")](" + buildUrl + ")";

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -17,16 +17,17 @@ limitations under the License.
 */
 package com.github.terma.jenkins.githubprcoveragestatus;
 
-import hudson.EnvVars;
-import hudson.model.Build;
-import hudson.model.Result;
-import hudson.model.TaskListener;
+import java.io.IOException;
+import java.io.PrintStream;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.io.PrintStream;
+import hudson.EnvVars;
+import hudson.model.Build;
+import hudson.model.Result;
+import hudson.model.TaskListener;
 
 public class CompareCoverageActionTest {
 
@@ -65,7 +66,7 @@ public class CompareCoverageActionTest {
 
         new CompareCoverageAction().perform(build, null, null, listener);
 
-        Mockito.verify(pullRequestRepository).comment(null, 12, "[![Coverage](aaa/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
+        Mockito.verify(pullRequestRepository).comment(null, 12, "[![0% (0.0%) vs master 0%](aaa/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
     }
 
     @Test
@@ -80,7 +81,7 @@ public class CompareCoverageActionTest {
 
         new CompareCoverageAction().perform(build, null, null, listener);
 
-        Mockito.verify(pullRequestRepository).comment(null, 12, "[![Coverage](customJ/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
+        Mockito.verify(pullRequestRepository).comment(null, 12, "[![0% (0.0%) vs master 0%](customJ/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
     }
 
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/MessageTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/MessageTest.java
@@ -51,23 +51,23 @@ public class MessageTest {
         String buildUrl = "http://terma.com/jenkins/job/ama";
         String jenkinsUrl = "jenkinsUrl";
         Assert.assertEquals(
-                "[![Coverage](jenkinsUrl/coverage-status-icon/?coverage=1.0&masterCoverage=1.0)](http://terma.com/jenkins/job/ama)",
+                "[![100% (0.0%) vs master 100%](jenkinsUrl/coverage-status-icon/?coverage=1.0&masterCoverage=1.0)](http://terma.com/jenkins/job/ama)",
                 new Message(1, 1).forComment(buildUrl, jenkinsUrl));
 
         Assert.assertEquals(
-                "[![Coverage](jenkinsUrl/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](http://terma.com/jenkins/job/ama)",
+                "[![0% (0.0%) vs master 0%](jenkinsUrl/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](http://terma.com/jenkins/job/ama)",
                 new Message(0, 0).forComment(buildUrl, jenkinsUrl));
 
         Assert.assertEquals(
-                "[![Coverage](jenkinsUrl/coverage-status-icon/?coverage=0.5&masterCoverage=0.0)](http://terma.com/jenkins/job/ama)",
+                "[![50% (+50.0%) vs master 0%](jenkinsUrl/coverage-status-icon/?coverage=0.5&masterCoverage=0.0)](http://terma.com/jenkins/job/ama)",
                 new Message(0.5f, 0).forComment(buildUrl, jenkinsUrl));
 
         Assert.assertEquals(
-                "[![Coverage](jenkinsUrl/coverage-status-icon/?coverage=0.0&masterCoverage=0.5)](http://terma.com/jenkins/job/ama)",
+                "[![0% (-50.0%) vs master 50%](jenkinsUrl/coverage-status-icon/?coverage=0.0&masterCoverage=0.5)](http://terma.com/jenkins/job/ama)",
                 new Message(0, 0.5f).forComment(buildUrl, jenkinsUrl));
 
         Assert.assertEquals(
-                "[![Coverage](jenkinsUrl/coverage-status-icon/?coverage=0.7&masterCoverage=0.5)](http://terma.com/jenkins/job/ama)",
+                "[![70% (+20.0%) vs master 50%](jenkinsUrl/coverage-status-icon/?coverage=0.7&masterCoverage=0.5)](http://terma.com/jenkins/job/ama)",
                 new Message(0.7f, 0.5f).forComment(buildUrl, jenkinsUrl));
     }
 


### PR DESCRIPTION
addresses https://github.com/terma/github-pr-coverage-status/issues/18

Our jenkins is not publicly available - so the image does not render - for us the coverage data still would help