### PR TITLE
use badges generated from shields.io

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
@@ -17,6 +17,11 @@ limitations under the License.
 */
 package com.github.terma.jenkins.githubprcoveragestatus;
 
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -29,10 +34,6 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import jenkins.tasks.SimpleBuildStep;
-import org.kohsuke.stapler.DataBoundConstructor;
-
-import java.io.IOException;
-import java.io.PrintStream;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class CompareCoverageAction extends Recorder implements SimpleBuildStep {
@@ -70,11 +71,12 @@ public class CompareCoverageAction extends Recorder implements SimpleBuildStep {
 
         final String buildUrl = Utils.getBuildUrl(build, listener);
 
-        String jenkinsUrl = ServiceRegistry.getSettingsRepository().getJenkinsUrl();
-        if (jenkinsUrl == null) jenkinsUrl = Utils.getJenkinsUrlFromBuildUrl(buildUrl);
+        final SettingsRepository settingsRepository = ServiceRegistry.getSettingsRepository();
+        final int yellowThreshold = settingsRepository.getYellowThreshold();
+        final int greenThreshold = settingsRepository.getGreenThreshold();
 
         try {
-            ServiceRegistry.getPullRequestRepository().comment(gitUrl, prId, message.forComment(buildUrl, jenkinsUrl));
+            ServiceRegistry.getPullRequestRepository().comment(gitUrl, prId, message.forComment(buildUrl, yellowThreshold, greenThreshold));
         } catch (IOException ex) {
             listener.error("Couldn't add comment to pull request #" + prId + "!", ex);
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -17,17 +17,18 @@ limitations under the License.
 */
 package com.github.terma.jenkins.githubprcoveragestatus;
 
-import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import net.sf.json.JSONObject;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import net.sf.json.JSONObject;
 
 @SuppressWarnings("WeakerAccess")
 public class Configuration extends AbstractDescribableImpl<Configuration> {
@@ -114,10 +115,12 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             return personalAccessToken;
         }
 
+        @Override
         public int getYellowThreshold() {
             return yellowThreshold;
         }
 
+        @Override
         public int getGreenThreshold() {
             return greenThreshold;
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CoverageStatusIconAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CoverageStatusIconAction.java
@@ -1,13 +1,14 @@
 package com.github.terma.jenkins.githubprcoveragestatus;
 
-import hudson.Extension;
-import hudson.model.UnprotectedRootAction;
+import java.io.IOException;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import java.io.IOException;
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
 
 @Extension
 public class CoverageStatusIconAction implements UnprotectedRootAction {

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
@@ -8,4 +8,7 @@ interface SettingsRepository {
 
     String getJenkinsUrl();
 
+    int getYellowThreshold();
+
+    int getGreenThreshold();
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -66,7 +66,7 @@ public class CompareCoverageActionTest {
 
         new CompareCoverageAction().perform(build, null, null, listener);
 
-        Mockito.verify(pullRequestRepository).comment(null, 12, "[![0% (0.0%) vs master 0%](aaa/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
+        Mockito.verify(pullRequestRepository).comment(null, 12, "[![0% (0.0%) vs master 0%](https://img.shields.io/badge/coverage-0%25%20(0.0%25)%20vs%20master%200%25-brightgreen.svg)](aaa/job/a)");
     }
 
     @Test
@@ -81,7 +81,7 @@ public class CompareCoverageActionTest {
 
         new CompareCoverageAction().perform(build, null, null, listener);
 
-        Mockito.verify(pullRequestRepository).comment(null, 12, "[![0% (0.0%) vs master 0%](customJ/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
+        Mockito.verify(pullRequestRepository).comment(null, 12, "[![0% (0.0%) vs master 0%](https://img.shields.io/badge/coverage-0%25%20(0.0%25)%20vs%20master%200%25-brightgreen.svg)](aaa/job/a)");
     }
 
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/MessageTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/MessageTest.java
@@ -51,24 +51,23 @@ public class MessageTest {
         String buildUrl = "http://terma.com/jenkins/job/ama";
         String jenkinsUrl = "jenkinsUrl";
         Assert.assertEquals(
-                "[![100% (0.0%) vs master 100%](jenkinsUrl/coverage-status-icon/?coverage=1.0&masterCoverage=1.0)](http://terma.com/jenkins/job/ama)",
-                new Message(1, 1).forComment(buildUrl, jenkinsUrl));
+                "[![100% (0.0%) vs master 100%](https://img.shields.io/badge/coverage-100%25%20(0.0%25)%20vs%20master%20100%25-brightgreen.svg)](http://terma.com/jenkins/job/ama)",
+                new Message(1, 1).forComment(buildUrl, 80, 90));
 
         Assert.assertEquals(
-                "[![0% (0.0%) vs master 0%](jenkinsUrl/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](http://terma.com/jenkins/job/ama)",
-                new Message(0, 0).forComment(buildUrl, jenkinsUrl));
+                "[![0% (0.0%) vs master 0%](https://img.shields.io/badge/coverage-0%25%20(0.0%25)%20vs%20master%200%25-red.svg)](http://terma.com/jenkins/job/ama)",
+                new Message(0, 0).forComment(buildUrl, 80, 90));
 
         Assert.assertEquals(
-                "[![50% (+50.0%) vs master 0%](jenkinsUrl/coverage-status-icon/?coverage=0.5&masterCoverage=0.0)](http://terma.com/jenkins/job/ama)",
-                new Message(0.5f, 0).forComment(buildUrl, jenkinsUrl));
+                "[![50% (+50.0%) vs master 0%](https://img.shields.io/badge/coverage-50%25%20(%2B50.0%25)%20vs%20master%200%25-red.svg)](http://terma.com/jenkins/job/ama)",
+                new Message(0.5f, 0).forComment(buildUrl, 80, 90));
 
         Assert.assertEquals(
-                "[![0% (-50.0%) vs master 50%](jenkinsUrl/coverage-status-icon/?coverage=0.0&masterCoverage=0.5)](http://terma.com/jenkins/job/ama)",
-                new Message(0, 0.5f).forComment(buildUrl, jenkinsUrl));
+                "[![0% (-50.0%) vs master 50%](https://img.shields.io/badge/coverage-0%25%20(-50.0%25)%20vs%20master%2050%25-red.svg)](http://terma.com/jenkins/job/ama)",
+                new Message(0, 0.5f).forComment(buildUrl, 80, 90));
 
         Assert.assertEquals(
-                "[![70% (+20.0%) vs master 50%](jenkinsUrl/coverage-status-icon/?coverage=0.7&masterCoverage=0.5)](http://terma.com/jenkins/job/ama)",
-                new Message(0.7f, 0.5f).forComment(buildUrl, jenkinsUrl));
+                "[![85% (+35.0%) vs master 50%](https://img.shields.io/badge/coverage-85%25%20(%2B35.0%25)%20vs%20master%2050%25-yellow.svg)](http://terma.com/jenkins/job/ama)",
+                new Message(0.85f, 0.5f).forComment(buildUrl, 80, 90));
     }
-
 }


### PR DESCRIPTION
I found the online service http://shields.io/ that lets you generate nice badges. 
Using this service would eliminate the need to access jenkins to render the badge. So the plugin would work also in scenarios where the jenkins is not accessible from github.

The badges would look like this:
![100% (0.0%) vs master 100%](https://img.shields.io/badge/coverage-100%25%20(0.0%25)%20vs%20master%20100%25-brightgreen.svg)

![85% (+35.0%) vs master 50%](https://img.shields.io/badge/coverage-85%25%20(%2B35.0%25)%20vs%20master%2050%25-yellow.svg)

![0% (0.0%) vs master 0%](https://img.shields.io/badge/coverage-0%25%20(0.0%25)%20vs%20master%200%25-red.svg)

What do you think?

I am new to jenkins plugin development so I did not test this in a running instance actually. Have to figure out how this works.