### PR TITLE
add sonarqube backend for master coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
             <artifactId>json-path</artifactId>
             <version>2.2.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
@@ -63,7 +63,7 @@ public class CompareCoverageAction extends Recorder implements SimpleBuildStep {
                             "to trigger build!");
         }
 
-        final float masterCoverage = ServiceRegistry.getMasterCoverageRepository().get(gitUrl);
+        final float masterCoverage = ServiceRegistry.getMasterCoverageRepository(buildLog).get(gitUrl);
         final float coverage = ServiceRegistry.getCoverageRepository().get(workspace);
 
         final Message message = new Message(coverage, masterCoverage);

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -57,6 +57,14 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         return DESCRIPTOR.getPersonalAccessToken();
     }
 
+    public static String getSonarUrl() {
+        return DESCRIPTOR.getSonarUrl();
+    }
+
+    public static Boolean isUseSonarForMasterCoverage() {
+        return DESCRIPTOR.isUseSonarForMasterCoverage();
+    }
+
     public static void setMasterCoverage(final String repo, final float coverage) {
         DESCRIPTOR.set(repo, coverage);
     }
@@ -79,6 +87,8 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         private String personalAccessToken;
         private String jenkinsUrl;
         private boolean privateJenkinsPublicGitHub;
+        private boolean useSonarForMasterCoverage;
+        private String sonarUrl;
 
         private int yellowThreshold = DEFAULT_YELLOW_THRESHOLD;
         private int greenThreshold = DEFAULT_GREEN_THRESHOLD;
@@ -133,6 +143,16 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         }
 
         @Override
+        public boolean isUseSonarForMasterCoverage() {
+            return useSonarForMasterCoverage;
+        }
+
+        @Override
+        public String getSonarUrl() {
+            return sonarUrl;
+        }
+
+        @Override
         public String getJenkinsUrl() {
             return jenkinsUrl;
         }
@@ -145,6 +165,8 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             greenThreshold = NumberUtils.toInt(formData.getString("greenThreshold"), DEFAULT_GREEN_THRESHOLD);
             jenkinsUrl = StringUtils.trimToNull(formData.getString("jenkinsUrl"));
             privateJenkinsPublicGitHub = BooleanUtils.toBoolean(formData.getString("privateJenkinsPublicGitHub"));
+            useSonarForMasterCoverage = BooleanUtils.toBoolean(formData.getString("useSonarForMasterCoverage"));
+            sonarUrl = StringUtils.trimToNull(formData.getString("sonarUrl"));
             save();
             return super.configure(req, formData);
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/ServiceRegistry.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/ServiceRegistry.java
@@ -1,5 +1,7 @@
 package com.github.terma.jenkins.githubprcoveragestatus;
 
+import java.io.PrintStream;
+
 public class ServiceRegistry {
 
     private static MasterCoverageRepository masterCoverageRepository;
@@ -7,12 +9,12 @@ public class ServiceRegistry {
     private static SettingsRepository settingsRepository;
     private static PullRequestRepository pullRequestRepository;
 
-    public static MasterCoverageRepository getMasterCoverageRepository() {
+    public static MasterCoverageRepository getMasterCoverageRepository(PrintStream buildLog) {
         if (masterCoverageRepository != null) {
             return masterCoverageRepository;
         } else {
-            if (Configuration.isUseSonarForMasterCoverage() && Configuration.getSonarUrl() != null) {
-                return new SonarMasterCoverageRepository(Configuration.getSonarUrl());
+            if (Configuration.getSonarUrl() != null) {
+                return new SonarMasterCoverageRepository(Configuration.getSonarUrl(), buildLog);
             } else {
                return Configuration.DESCRIPTOR;
             }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/ServiceRegistry.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/ServiceRegistry.java
@@ -8,7 +8,15 @@ public class ServiceRegistry {
     private static PullRequestRepository pullRequestRepository;
 
     public static MasterCoverageRepository getMasterCoverageRepository() {
-        return masterCoverageRepository != null ? masterCoverageRepository : Configuration.DESCRIPTOR;
+        if (masterCoverageRepository != null) {
+            return masterCoverageRepository;
+        } else {
+            if (Configuration.isUseSonarForMasterCoverage() && Configuration.getSonarUrl() != null) {
+                return new SonarMasterCoverageRepository(Configuration.getSonarUrl());
+            } else {
+               return Configuration.DESCRIPTOR;
+            }
+        }
     }
 
     public static void setMasterCoverageRepository(MasterCoverageRepository masterCoverageRepository) {

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
@@ -14,4 +14,7 @@ interface SettingsRepository {
 
     boolean isPrivateJenkinsPublicGitHub();
 
+    boolean isUseSonarForMasterCoverage();
+
+    String getSonarUrl();
 }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
@@ -1,15 +1,13 @@
 package com.github.terma.jenkins.githubprcoveragestatus;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static java.util.logging.Level.INFO;
-import static java.util.logging.Level.SEVERE;
-import static java.util.logging.Level.WARNING;
+import static org.apache.commons.httpclient.HttpStatus.SC_BAD_REQUEST;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URLEncoder;
 import java.text.MessageFormat;
 import java.util.List;
-import java.util.logging.Logger;
 
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -21,42 +19,44 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class SonarMasterCoverageRepository implements MasterCoverageRepository {
 
-    private static final transient Logger logger = Logger.getLogger(SonarMasterCoverageRepository.class.getName());
 
     private static final String SONAR_SEARCH_PROJECTS_API_PATH = "/api/projects/index";
     private static final String SONAR_COMPONENT_MEASURE_API_PATH = "/api/measures/component";
     private static final String SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME = "overall_line_coverage";
 
     private final String sonarEndpoint;
+    private PrintStream buildLog;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
 
-    public SonarMasterCoverageRepository(String sonarEndpoint) {
+    public SonarMasterCoverageRepository(String sonarEndpoint, PrintStream buildLog) {
         this.sonarEndpoint = sonarEndpoint;
+        this.buildLog = buildLog;
         httpClient = new HttpClient();
     }
 
     @Override
     public float get(String gitUrl) {
-        logger.log(INFO, "Getting coverage for {0}", gitUrl);
+        log("Getting coverage for %s", gitUrl);
 
         try {
             final SonarProject sonarProject = getSonarProject(gitUrl);
-            if (sonarProject != null) {
-                return getCoverageMeasure(sonarProject);
-            } else {
-                return 0;
-            }
+            return getCoverageMeasure(sonarProject);
         } catch (Exception e) {
-            logger.log(SEVERE, "failed to get master coverage for " + gitUrl, e);
+            log("Failed to get master coverage for %s", gitUrl);
+            log("Exception message '%s'", e);
+            e.printStackTrace(buildLog);
             return 0;
         }
     }
 
     /**
      * Try to find the project in sonarqube based on the repo name from the git uri
+     *
+     * @return the sonar project found in case multiple are found, the first one is returned
+     * @throws SonarProjectRetrievalException if no project could be found or an error occurred during retrieval
      */
-    private SonarProject getSonarProject(String gitUrl) throws Exception {
+    private SonarProject getSonarProject(String gitUrl) throws SonarProjectRetrievalException {
         String repoName = StringUtils.substringAfterLast(StringUtils.removeEnd(gitUrl, ".git"), "/");
 
         final String searchUri = sonarEndpoint + SONAR_SEARCH_PROJECTS_API_PATH + "?search=" + repoName;
@@ -65,25 +65,26 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
             List<SonarProject> sonarProjects = objectMapper.readValue(method.getResponseBodyAsStream(), new TypeReference<List<SonarProject>>() {});
 
             if (sonarProjects.isEmpty()) {
-                logger.log(WARNING, "No sonar project found for repo {0}", repoName);
-                throw new RuntimeException("No sonar project found for repo" + repoName);
+                throw new SonarProjectRetrievalException("No sonar project found for repo" + repoName);
             } else if (sonarProjects.size() == 1) {
-                logger.log(INFO, "Found project for repo name {0} - {1}", new Object[]{repoName, sonarProjects.get(0)});
+                log("Found project for repo name {0} - {1}", repoName, sonarProjects.get(0));
                 return sonarProjects.get(0);
             } else {
-                logger.log(INFO, "Found multiple projects for repo name {0} - found {1} - returning first result", new Object[]{repoName, sonarProjects.toArray()});
+                log("Found multiple projects for repo name {0} - found {1} - returning first result", repoName, sonarProjects.toArray());
                 return sonarProjects.get(0);
             }
         } catch (Exception e) {
-            logger.log(SEVERE, "failed to search for sonar project {0} - {1}", new Object[]{searchUri, e.getMessage()});
-            throw e;
+            throw new SonarProjectRetrievalException(String.format("failed to search for sonar project %s - %s", searchUri, e.getMessage()), e);
         }
     }
 
     /**
      * Try to find code coverage measure for project in sonarqube
+     *
+     * @return the coverage found for the project
+     * @throws SonarCoverageMeasureRetrievalException if an error occurred during retrieval of the coverage
      */
-    private float getCoverageMeasure(SonarProject project) throws Exception {
+    private float getCoverageMeasure(SonarProject project) throws SonarCoverageMeasureRetrievalException {
 
         final String uri = MessageFormat.format("{0}{1}?componentKey={2}&metricKeys={3}", sonarEndpoint, SONAR_COMPONENT_MEASURE_API_PATH, URLEncoder.encode(project.getKey()), SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME);
         try {
@@ -91,15 +92,14 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
             String value = JsonUtils.findInJson(method.getResponseBodyAsString(), "component.measures[0].value");
             return Float.valueOf(value) / 100;
         } catch (Exception e) {
-            logger.log(SEVERE, "failed to get coverage for sonar project {0} {1}", new Object[]{uri, e});
-            throw e;
+            throw new SonarCoverageMeasureRetrievalException(String.format("failed to get coverage measure for sonar project %s - %s", project.getKey(), e.getMessage()), e);
         }
     }
 
     private GetMethod executeGetRequest(String uri) throws IOException, HttpClientException {
         final GetMethod method = new GetMethod(uri);
         int status = httpClient.executeMethod(method);
-        if (status >= 400) {
+        if (status >= SC_BAD_REQUEST) {
             throw new HttpClientException(uri, status, method.getResponseBodyAsString());
         }
         return method;
@@ -109,6 +109,11 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
         HttpClientException(String uri, int status, String reason) {
             super("request to "  + uri + " failed with " + status + " reason " + reason);
         }
+    }
+
+    private void log(String format, Object... arguments) {
+        buildLog.printf(format, arguments);
+        buildLog.println();
     }
 
     private static class SonarProject {
@@ -126,6 +131,23 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
         @Override
         public String toString() {
             return MessageFormat.format("({0}(key = {1}))", this.getClass().getSimpleName(), key);
+        }
+    }
+
+    private static class SonarProjectRetrievalException extends Exception {
+        private SonarProjectRetrievalException(String message) {
+            super(message);
+        }
+
+        private SonarProjectRetrievalException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private static class SonarCoverageMeasureRetrievalException extends Exception {
+
+        private SonarCoverageMeasureRetrievalException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
@@ -1,0 +1,131 @@
+package com.github.terma.jenkins.githubprcoveragestatus;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SonarMasterCoverageRepository implements MasterCoverageRepository {
+
+    private static final transient Logger logger = Logger.getLogger(SonarMasterCoverageRepository.class.getName());
+
+    private static final String SONAR_SEARCH_PROJECTS_API_PATH = "/api/projects/index";
+    private static final String SONAR_COMPONENT_MEASURE_API_PATH = "/api/measures/component";
+    private static final String SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME = "overall_line_coverage";
+
+    private final String sonarEndpoint;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
+
+    public SonarMasterCoverageRepository(String sonarEndpoint) {
+        this.sonarEndpoint = sonarEndpoint;
+        httpClient = new HttpClient();
+    }
+
+    @Override
+    public float get(String gitUrl) {
+        logger.log(INFO, "Getting coverage for {0}", gitUrl);
+
+        try {
+            final SonarProject sonarProject = getSonarProject(gitUrl);
+            if (sonarProject != null) {
+                return getCoverageMeasure(sonarProject);
+            } else {
+                return 0;
+            }
+        } catch (Exception e) {
+            logger.log(SEVERE, "failed to get master coverage for " + gitUrl, e);
+            return 0;
+        }
+    }
+
+    /**
+     * Try to find the project in sonarqube based on the repo name from the git uri
+     */
+    private SonarProject getSonarProject(String gitUrl) throws Exception {
+        String repoName = StringUtils.substringAfterLast(StringUtils.removeEnd(gitUrl, ".git"), "/");
+
+        final String searchUri = sonarEndpoint + SONAR_SEARCH_PROJECTS_API_PATH + "?search=" + repoName;
+        try {
+            final GetMethod method = executeGetRequest(searchUri);
+            List<SonarProject> sonarProjects = objectMapper.readValue(method.getResponseBodyAsStream(), new TypeReference<List<SonarProject>>() {});
+
+            if (sonarProjects.isEmpty()) {
+                logger.log(WARNING, "No sonar project found for repo {0}", repoName);
+                throw new RuntimeException("No sonar project found for repo" + repoName);
+            } else if (sonarProjects.size() == 1) {
+                logger.log(INFO, "Found project for repo name {0} - {1}", new Object[]{repoName, sonarProjects.get(0)});
+                return sonarProjects.get(0);
+            } else {
+                logger.log(INFO, "Found multiple projects for repo name {0} - found {1} - returning first result", new Object[]{repoName, sonarProjects.toArray()});
+                return sonarProjects.get(0);
+            }
+        } catch (Exception e) {
+            logger.log(SEVERE, "failed to search for sonar project {0} - {1}", new Object[]{searchUri, e.getMessage()});
+            throw e;
+        }
+    }
+
+    /**
+     * Try to find code coverage measure for project in sonarqube
+     */
+    private float getCoverageMeasure(SonarProject project) throws Exception {
+
+        final String uri = MessageFormat.format("{0}{1}?componentKey={2}&metricKeys={3}", sonarEndpoint, SONAR_COMPONENT_MEASURE_API_PATH, URLEncoder.encode(project.getKey()), SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME);
+        try {
+            final GetMethod method = executeGetRequest(uri);
+            String value = JsonUtils.findInJson(method.getResponseBodyAsString(), "component.measures[0].value");
+            return Float.valueOf(value) / 100;
+        } catch (Exception e) {
+            logger.log(SEVERE, "failed to get coverage for sonar project {0} {1}", new Object[]{uri, e});
+            throw e;
+        }
+    }
+
+    private GetMethod executeGetRequest(String uri) throws IOException, HttpClientException {
+        final GetMethod method = new GetMethod(uri);
+        int status = httpClient.executeMethod(method);
+        if (status >= 400) {
+            throw new HttpClientException(uri, status, method.getResponseBodyAsString());
+        }
+        return method;
+    }
+
+    private static class  HttpClientException extends Exception {
+        HttpClientException(String uri, int status, String reason) {
+            super("request to "  + uri + " failed with " + status + " reason " + reason);
+        }
+    }
+
+    private static class SonarProject {
+        @JsonProperty("k")
+        String key;
+
+        String getKey() {
+            return key;
+        }
+
+        void setKey(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String toString() {
+            return MessageFormat.format("({0}(key = {1}))", this.getClass().getSimpleName(), key);
+        }
+    }
+}

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
@@ -28,4 +28,12 @@ f.section(title: descriptor.displayName) {
         f.textbox()
     }
 
+    f.entry(field: "useSonarForMasterCoverage", title: _("Use Sonar as a backend for master coverage")) {
+        f.checkbox()
+    }
+
+    f.entry(field: "sonarUrl", title: _("Sonar endpoint URL")) {
+        f.textbox()
+    }
+
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest.java
@@ -5,9 +5,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.google.common.base.Charsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -18,19 +24,24 @@ public class SonarMasterCoverageRepositoryTest {
     @ClassRule
     public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(0));
 
+    private ByteArrayOutputStream buildLogOutputStream;
+
+    private SonarMasterCoverageRepository sonarMasterCoverageRepository;
+
     @Test
-    public void should_get_coverage() {
-        final SonarMasterCoverageRepository sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port());
+    public void should_get_coverage() throws IOException {
+        givenCoverageRepository();
 
         givenProjectResponseWithSingleMatch();
         givenMeasureResponse();
 
-        assertThat(sonarMasterCoverageRepository.get("git@github.com:some/my-project.git"), is(0.953f));
+        final float coverage = sonarMasterCoverageRepository.get("git@github.com:some/my-project.git");
+        assertThat(coverage, is(0.953f));
     }
 
     @Test
     public void should_get_zero_coverage_for_not_found() {
-        final SonarMasterCoverageRepository sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port());
+        givenCoverageRepository();
 
         givenProjectResponseWithoutMatch();
 
@@ -38,8 +49,8 @@ public class SonarMasterCoverageRepositoryTest {
     }
 
     @Test
-    public void should_get_zero_coverage_for_unknown_metric() {
-        final SonarMasterCoverageRepository sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port());
+    public void should_get_zero_coverage_for_unknown_metric() throws IOException {
+        givenCoverageRepository();
 
         givenProjectResponseWithSingleMatch();
         givenNotFoundMeasureResponse();
@@ -47,20 +58,18 @@ public class SonarMasterCoverageRepositoryTest {
         assertThat(sonarMasterCoverageRepository.get("git@github.com:some/my-project.git"), is(0f));
     }
 
-    private void givenProjectResponseWithSingleMatch() {
+    private void givenCoverageRepository() {
+        buildLogOutputStream = new ByteArrayOutputStream();
+        sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port(),
+                new PrintStream(buildLogOutputStream, true));
+    }
+
+    private void givenProjectResponseWithSingleMatch() throws IOException {
         wireMockRule.stubFor(get(urlPathEqualTo("/api/projects/index"))
                 .withQueryParam("search", equalTo("my-project"))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withBody("[\n" +
-                                "    {\n" +
-                                "        \"id\": \"7408\", \n" +
-                                "        \"k\": \"my-project:origin/master\", \n" +
-                                "        \"nm\": \"my-project origin/master\", \n" +
-                                "        \"qu\": \"TRK\", \n" +
-                                "        \"sc\": \"PRJ\"\n" +
-                                "    }\n" +
-                                "]")
+                        .withBody(getResponseBodyFromFile("singleProjectFound.json"))
                 )
         );
     }
@@ -75,58 +84,29 @@ public class SonarMasterCoverageRepositoryTest {
         );
     }
 
-    private void givenMeasureResponse() {
+    private void givenMeasureResponse() throws IOException {
         wireMockRule.stubFor(get(urlPathEqualTo("/api/measures/component"))
                 .withQueryParam("componentKey", equalTo("my-project:origin/master"))
                 .withQueryParam("metricKeys", equalTo("overall_line_coverage"))
                 .willReturn(aResponse()
                         .withStatus(200)
-                        .withBody("{\n" +
-                                "    \"component\": {\n" +
-                                "        \"id\": \"AVYsqpbS80EniRC8Nh21\", \n" +
-                                "        \"key\": \"my-project:origin/master\", \n" +
-                                "        \"measures\": [\n" +
-                                "            {\n" +
-                                "                \"metric\": \"overall_line_coverage\", \n" +
-                                "                \"periods\": [\n" +
-                                "                    {\n" +
-                                "                        \"index\": 1, \n" +
-                                "                        \"value\": \"0.0\"\n" +
-                                "                    }, \n" +
-                                "                    {\n" +
-                                "                        \"index\": 2, \n" +
-                                "                        \"value\": \"0.0\"\n" +
-                                "                    }, \n" +
-                                "                    {\n" +
-                                "                        \"index\": 3, \n" +
-                                "                        \"value\": \"0.29999999999999716\"\n" +
-                                "                    }\n" +
-                                "                ], \n" +
-                                "                \"value\": \"95.3\"\n" +
-                                "            }\n" +
-                                "        ], \n" +
-                                "        \"name\": \"my-project origin/master\", \n" +
-                                "        \"qualifier\": \"TRK\"\n" +
-                                "    }\n" +
-                                "}")
+                        .withBody(getResponseBodyFromFile("measureFound.json"))
                 )
         );
     }
 
-    private void givenNotFoundMeasureResponse() {
+    private void givenNotFoundMeasureResponse() throws IOException {
         wireMockRule.stubFor(get(urlPathEqualTo("/api/measures/component"))
                 .withQueryParam("componentKey", equalTo("my-project:origin/master"))
                 .withQueryParam("metricKeys", equalTo("overall_line_coverage"))
                 .willReturn(aResponse()
                         .withStatus(404)
-                        .withBody("{\n" +
-                                "    \"errors\": [\n" +
-                                "        {\n" +
-                                "            \"msg\": \"The following metric keys are not found: overall_line_coverages\"\n" +
-                                "        }\n" +
-                                "    ]\n" +
-                                "}")
+                        .withBody(getResponseBodyFromFile("metricNotFound.json"))
                 )
         );
+    }
+
+    private String getResponseBodyFromFile(String fileName) throws IOException {
+        return IOUtils.toString(this.getClass().getResourceAsStream("/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/" + fileName), UTF_8);
     }
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest.java
@@ -1,0 +1,132 @@
+package com.github.terma.jenkins.githubprcoveragestatus;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+public class SonarMasterCoverageRepositoryTest {
+
+    @ClassRule
+    public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(0));
+
+    @Test
+    public void should_get_coverage() {
+        final SonarMasterCoverageRepository sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port());
+
+        givenProjectResponseWithSingleMatch();
+        givenMeasureResponse();
+
+        assertThat(sonarMasterCoverageRepository.get("git@github.com:some/my-project.git"), is(0.953f));
+    }
+
+    @Test
+    public void should_get_zero_coverage_for_not_found() {
+        final SonarMasterCoverageRepository sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port());
+
+        givenProjectResponseWithoutMatch();
+
+        assertThat(sonarMasterCoverageRepository.get("git@github.com:some/my-project.git"), is(0f));
+    }
+
+    @Test
+    public void should_get_zero_coverage_for_unknown_metric() {
+        final SonarMasterCoverageRepository sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port());
+
+        givenProjectResponseWithSingleMatch();
+        givenNotFoundMeasureResponse();
+
+        assertThat(sonarMasterCoverageRepository.get("git@github.com:some/my-project.git"), is(0f));
+    }
+
+    private void givenProjectResponseWithSingleMatch() {
+        wireMockRule.stubFor(get(urlPathEqualTo("/api/projects/index"))
+                .withQueryParam("search", equalTo("my-project"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("[\n" +
+                                "    {\n" +
+                                "        \"id\": \"7408\", \n" +
+                                "        \"k\": \"my-project:origin/master\", \n" +
+                                "        \"nm\": \"my-project origin/master\", \n" +
+                                "        \"qu\": \"TRK\", \n" +
+                                "        \"sc\": \"PRJ\"\n" +
+                                "    }\n" +
+                                "]")
+                )
+        );
+    }
+
+    private void givenProjectResponseWithoutMatch() {
+        wireMockRule.stubFor(get(urlPathEqualTo("/api/projects/index"))
+                .withQueryParam("search", equalTo("my-project"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("[]")
+                )
+        );
+    }
+
+    private void givenMeasureResponse() {
+        wireMockRule.stubFor(get(urlPathEqualTo("/api/measures/component"))
+                .withQueryParam("componentKey", equalTo("my-project:origin/master"))
+                .withQueryParam("metricKeys", equalTo("overall_line_coverage"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("{\n" +
+                                "    \"component\": {\n" +
+                                "        \"id\": \"AVYsqpbS80EniRC8Nh21\", \n" +
+                                "        \"key\": \"my-project:origin/master\", \n" +
+                                "        \"measures\": [\n" +
+                                "            {\n" +
+                                "                \"metric\": \"overall_line_coverage\", \n" +
+                                "                \"periods\": [\n" +
+                                "                    {\n" +
+                                "                        \"index\": 1, \n" +
+                                "                        \"value\": \"0.0\"\n" +
+                                "                    }, \n" +
+                                "                    {\n" +
+                                "                        \"index\": 2, \n" +
+                                "                        \"value\": \"0.0\"\n" +
+                                "                    }, \n" +
+                                "                    {\n" +
+                                "                        \"index\": 3, \n" +
+                                "                        \"value\": \"0.29999999999999716\"\n" +
+                                "                    }\n" +
+                                "                ], \n" +
+                                "                \"value\": \"95.3\"\n" +
+                                "            }\n" +
+                                "        ], \n" +
+                                "        \"name\": \"my-project origin/master\", \n" +
+                                "        \"qualifier\": \"TRK\"\n" +
+                                "    }\n" +
+                                "}")
+                )
+        );
+    }
+
+    private void givenNotFoundMeasureResponse() {
+        wireMockRule.stubFor(get(urlPathEqualTo("/api/measures/component"))
+                .withQueryParam("componentKey", equalTo("my-project:origin/master"))
+                .withQueryParam("metricKeys", equalTo("overall_line_coverage"))
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withBody("{\n" +
+                                "    \"errors\": [\n" +
+                                "        {\n" +
+                                "            \"msg\": \"The following metric keys are not found: overall_line_coverages\"\n" +
+                                "        }\n" +
+                                "    ]\n" +
+                                "}")
+                )
+        );
+    }
+}

--- a/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/measureFound.json
+++ b/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/measureFound.json
@@ -1,0 +1,28 @@
+{
+  "component": {
+    "id": "AVePr_fQwz0tAcNAWEGz",
+    "key": "my-project:origin/master",
+    "measures": [
+      {
+        "metric": "overall_line_coverage",
+        "periods": [
+          {
+            "index": 1,
+            "value": "0.0"
+          },
+          {
+            "index": 2,
+            "value": "0.0"
+          },
+          {
+            "index": 3,
+            "value": "0.0"
+          }
+        ],
+        "value": "95.3"
+      }
+    ],
+    "name": "my-project origin/master",
+    "qualifier": "TRK"
+  }
+}

--- a/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/metricNotFound.json
+++ b/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/metricNotFound.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "msg": "The following metric keys are not found: overall_line_coverages"
+    }
+  ]
+}

--- a/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/singleProjectFound.json
+++ b/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/singleProjectFound.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "10400",
+    "k": "my-project:origin/master",
+    "nm": "my-project origin/master",
+    "qu": "TRK",
+    "sc": "PRJ"
+  }
+]


### PR DESCRIPTION
as already discussed earlier via mail I am adding the possibility to get master coverage from a sonarqube backend

The plugin uses the plugin configuration file to store master coverage. We run jenkins in docker and the plugin config file is part of the docker image. So we always start with an empty master coverage when a new jenkins docker image is deployed (which happens frequently).

I added a different implementation of `MasterCoverageRepository` that connects against a sonarqube server, tries to find a matching project there and then tries to read the `overall_line_coverage` for this project.  See `SonarMasterCoverageRepository`

This behavior can be switched on using the configuration - to the plugin behaves as before with the default configuration.

I tested against a sonarqube 6.0 server.

The current implementation is still very basic - but it is a starting point that we could use to see if this feature is interesting for people out there. If so we can extend it.

@terma what do you think?