### PR TITLE
NPE in CachedGitHubRepository

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CachedGitHubRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CachedGitHubRepository.java
@@ -59,9 +59,9 @@ class CachedGitHubRepository {
         }
     }
 
-    private boolean initGitHubRepository(final String gitHubUrl) {
+    private void initGitHubRepository(final String gitHubUrl) {
         if (gitHubRepository != null) {
-            return true;
+            return;
         }
 
         GitHub gitHub;
@@ -70,12 +70,13 @@ class CachedGitHubRepository {
             gitHub = getGitHub();
         } catch (IOException ex) {
             logger.log(Level.SEVERE, "Error while accessing rate limit API", ex);
-            return false;
+            throw ex;
         }
 
         if (gitHub == null) {
-            logger.log(Level.SEVERE, "No connection returned to GitHub server!");
-            return false;
+            final IOException ex = new IOException("No connection returned to GitHub server!");
+            logger.log(Level.SEVERE, ex.getMessage());
+            throw ex;
         }
 
         try {
@@ -84,11 +85,11 @@ class CachedGitHubRepository {
                 return false;
             }
         } catch (FileNotFoundException ex) {
-            logger.log(Level.INFO, "Rate limit API not found.");
-            return false;
+            logger.log(Level.SEVERE, "Rate limit API not found.");
+            throw ex;
         } catch (IOException ex) {
             logger.log(Level.SEVERE, "Error while accessing rate limit API", ex);
-            return false;
+            throw ex;
         }
 
         final String userRepo = Utils.getUserRepo(gitHubUrl);
@@ -98,9 +99,7 @@ class CachedGitHubRepository {
         } catch (IOException ex) {
             logger.log(Level.SEVERE, "Could not retrieve GitHub repository named " + userRepo
                     + " (Do you have properly set 'GitHub project' field in job configuration?)", ex);
-            return false;
+            throw ex;
         }
-        return true;
     }
-
 }


### PR DESCRIPTION
Hello,

**I have an error using the plugin:**

```java
Coverage 48% changed -6.6% vs master 54%
ERROR: Build step failed with exception
java.lang.NullPointerException
	at com.github.terma.jenkins.githubprcoveragestatus.CachedGitHubRepository.getPullRequest(CachedGitHubRepository.java:39)
	at com.github.terma.jenkins.githubprcoveragestatus.GitHubPullRequestRepository.comment(GitHubPullRequestRepository.java:8)
	at com.github.terma.jenkins.githubprcoveragestatus.CompareCoverageAction.perform(CompareCoverageAction.java:86)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:78)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.post2(MavenModuleSetBuild.java:1046)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:668)
	at hudson.model.Run.execute(Run.java:1763)
	at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:531)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:410)
Build step 'Publish coverage to GitHub' marked build as failure
```

**Clue?**

Regarding this issue, I'd like to highlight that `CachedGitHubRepository#initGitHubRepository` returned value is not checked in line [CachedGitHubRepository:38](https://github.com/jenkinsci/github-pr-coverage-status-plugin/blob/master/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CachedGitHubRepository.java#L38).

**Fix?**

Should the method re-throw exception instead of returning boolean value?

*Code pushed in the pull request is only informational, it was just to start the discussion because I didn't find a way to log the issue.*