### PR TITLE
Add missing # to README hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/terma/github-pr-coverage-status/badge.svg?branch=master)](https://coveralls.io/github/terma/github-pr-coverage-status?branch=master)
 
 * [Overview](#overview)
-* [Supports coverage reports](supports-coverage-reports)
+* [Supports coverage reports](#supports-coverage-reports)
 * [How to use](#how-to-use)
 * [Troubleshooting](#troubleshooting)
 * [Changelog](#changelog)


### PR DESCRIPTION
Missing `#` in README.md that directs the user to a page that does not exist https://github.com/jenkinsci/github-pr-coverage-status-plugin/blob/master/supports-coverage-reports

Updated README.md so that the `Supports coverage reports` link in the `Overview` section directs the user to the correct `Supports Coverage Reports` section in the README.md.