### PR TITLE
Cobertura uses line, branch, or both depending on what's available

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParser.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParser.java
@@ -53,7 +53,13 @@ class CoberturaParser implements CoverageReportParser {
             String content = FileUtils.readFileToString(new File(coberturaFilePath));
             float lineRate = Float.parseFloat(findFirst(content, "line-rate=\"([0-9.]+)\""));
             float branchRate = Float.parseFloat(findFirst(content, "branch-rate=\"([0-9.]+)\""));
-            return lineRate / 2 + branchRate / 2;
+            if (lineRate > 0 && branchRate == 0) {
+              return lineRate;
+            } else if (lineRate == 0 && branchRate > 0) {
+              return branchRate;
+            } else {
+              return lineRate / 2 + branchRate / 2;
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest.java
@@ -45,7 +45,7 @@ public class CoberturaParserTest {
         String filePath = CoberturaParserTest.class.getResource(
                 "/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest/cobertura-zero-branch-rate.xml").getFile();
 
-        Assert.assertEquals(0.25, new CoberturaParser().get(filePath), 0.1);
+        Assert.assertEquals(0.5, new CoberturaParser().get(filePath), 0.1);
     }
 
     @Test
@@ -53,7 +53,7 @@ public class CoberturaParserTest {
         String filePath = CoberturaParserTest.class.getResource(
                 "/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest/cobertura-zero-line-rate.xml").getFile();
 
-        Assert.assertEquals(0.5, new CoberturaParser().get(filePath), 0.1);
+        Assert.assertEquals(1, new CoberturaParser().get(filePath), 0.1);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest.java
@@ -41,7 +41,7 @@ public class CoberturaParserTest {
     }
 
     @Test
-    public void extractCoverageIfBranchRateIsZero() throws IOException {
+    public void extractCoverageIfBranchRateIsZeroAndHasOnlyLineRate() throws IOException {
         String filePath = CoberturaParserTest.class.getResource(
                 "/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest/cobertura-zero-branch-rate.xml").getFile();
 
@@ -49,7 +49,7 @@ public class CoberturaParserTest {
     }
 
     @Test
-    public void extractCoverageIfLineRateIsZero() throws IOException {
+    public void extractCoverageIfLineRateIsZeroAndHasBranchRate() throws IOException {
         String filePath = CoberturaParserTest.class.getResource(
                 "/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParserTest/cobertura-zero-line-rate.xml").getFile();
 


### PR DESCRIPTION
Not all users of this plugin want the average of line coverage and branch coverage. Some folks prefer to go based solely on line coverage. Others may want only branch coverage. If you have branch coverage > 0, then you must have covered at least one line; however, you may not have specified that you want your line coverage output leading to `branch-rate>0` and `line-rate=0`. The same case goes for `line-rate`: if I cover at least one line, then I've coverage _some_ non-zero percent of the logical branches. If the coverage file says `branch-rate=0` then it was a configuration choice to only count line-coverage.
If both line and branch coverage are non-zero, then leave the behavior unaffected.

Let me know about any style changes you'd like to see :)

Also do I need to bump a minor-or-patch version here?