### PR TITLE
Add sonar token for authentication.

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -61,6 +61,10 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         return DESCRIPTOR.getSonarUrl();
     }
 
+    public static String getSonarToken() {
+        return DESCRIPTOR.getSonarToken();
+    }
+
     public static Boolean isUseSonarForMasterCoverage() {
         return DESCRIPTOR.isUseSonarForMasterCoverage();
     }
@@ -89,6 +93,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         private boolean privateJenkinsPublicGitHub;
         private boolean useSonarForMasterCoverage;
         private String sonarUrl;
+        private String sonarToken;
 
         private int yellowThreshold = DEFAULT_YELLOW_THRESHOLD;
         private int greenThreshold = DEFAULT_GREEN_THRESHOLD;
@@ -153,6 +158,11 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         }
 
         @Override
+        public String getSonarToken() {
+            return sonarToken;
+        }
+
+        @Override
         public String getJenkinsUrl() {
             return jenkinsUrl;
         }
@@ -167,6 +177,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             privateJenkinsPublicGitHub = BooleanUtils.toBoolean(formData.getString("privateJenkinsPublicGitHub"));
             useSonarForMasterCoverage = BooleanUtils.toBoolean(formData.getString("useSonarForMasterCoverage"));
             sonarUrl = StringUtils.trimToNull(formData.getString("sonarUrl"));
+            sonarToken = StringUtils.trimToNull(formData.getString("sonarToken"));
             save();
             return super.configure(req, formData);
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/ServiceRegistry.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/ServiceRegistry.java
@@ -14,7 +14,11 @@ public class ServiceRegistry {
             return masterCoverageRepository;
         } else {
             if (Configuration.isUseSonarForMasterCoverage()) {
-                return new SonarMasterCoverageRepository(Configuration.getSonarUrl(), buildLog);
+                return new SonarMasterCoverageRepository(
+                    Configuration.getSonarUrl(),
+                    Configuration.getSonarToken(),
+                    buildLog
+                );
             } else {
                 return Configuration.DESCRIPTOR;
             }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
@@ -17,4 +17,6 @@ interface SettingsRepository {
     boolean isUseSonarForMasterCoverage();
 
     String getSonarUrl();
+
+    String getSonarToken();
 }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -27,10 +29,14 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
     private final ObjectMapper objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
     private PrintStream buildLog;
 
-    public SonarMasterCoverageRepository(String sonarUrl, PrintStream buildLog) {
+    public SonarMasterCoverageRepository(String sonarUrl, String sonarToken, PrintStream buildLog) {
         this.sonarUrl = sonarUrl;
         this.buildLog = buildLog;
         httpClient = new HttpClient();
+        httpClient.getState().setCredentials(
+            new AuthScope(null, 0, null, null),
+            new UsernamePasswordCredentials(sonarToken, "")
+        );
     }
 
     @Override
@@ -95,6 +101,7 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
 
     private GetMethod executeGetRequest(String uri) throws IOException, HttpClientException {
         final GetMethod method = new GetMethod(uri);
+        method.setDoAuthentication(true);
         int status = httpClient.executeMethod(method);
         if (status >= SC_BAD_REQUEST) {
             throw new HttpClientException(uri, status, method.getResponseBodyAsString());

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
@@ -36,4 +36,8 @@ f.section(title: descriptor.displayName) {
         f.textbox()
     }
 
+    f.entry(field: "sonarToken", title: _("Sonar access token")) {
+        f.textbox()
+    }
+
 }

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/help-sonarToken.html
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/help-sonarToken.html
@@ -1,0 +1,3 @@
+<div>
+    Access token for Sonar instance
+</div>

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest.java
@@ -73,6 +73,7 @@ public class SonarMasterCoverageRepositoryTest {
     private void givenCoverageRepository() {
         buildLogOutputStream = new ByteArrayOutputStream();
         sonarMasterCoverageRepository = new SonarMasterCoverageRepository("http://localhost:" + wireMockRule.port(),
+                "myToken",
                 new PrintStream(buildLogOutputStream, true));
     }
 


### PR DESCRIPTION
Should add optional authentication for SonarQube through a generated token.

I'm having a hard time testing if this work as I keep getting 0%. Could you perhaps help me out by telling where these logs can be found? https://github.com/jenkinsci/github-pr-coverage-status-plugin/blob/edf2f6a2403b0bf786e729b004fda2c44eb090ba/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java#L45
I don't see any in the job log and neither the system log. I don't see "Getting coverage for ..." anywhere either.