### PR TITLE
cobertura parser: allow for single quotes around {branch,line}-rate

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParser.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CoberturaParser.java
@@ -51,8 +51,8 @@ class CoberturaParser implements CoverageReportParser {
     public float get(String coberturaFilePath) {
         try {
             String content = FileUtils.readFileToString(new File(coberturaFilePath));
-            float lineRate = Float.parseFloat(findFirst(content, "line-rate=\"([0-9.]+)\""));
-            float branchRate = Float.parseFloat(findFirst(content, "branch-rate=\"([0-9.]+)\""));
+            float lineRate = Float.parseFloat(findFirst(content, "line-rate=['\"]([0-9.]+)['\"]"));
+            float branchRate = Float.parseFloat(findFirst(content, "branch-rate=['\"]([0-9.]+)['\"]"));
             if (lineRate > 0 && branchRate == 0) {
               return lineRate;
             } else if (lineRate == 0 && branchRate > 0) {


### PR DESCRIPTION
I'm using [simplecov-cobertura](https://github.com/dashingrocket/simplecov-cobertura) to generate Cobertura reports for Ruby tests, and it puts single quotes around the `branch-rate` and `line-rate` values. This change allows for both single and double quotes.

I'm working on testing this now.