### PR TITLE
Fixes SimpleCovParser.get returns hundredfold value

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SimpleCovParser.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SimpleCovParser.java
@@ -24,7 +24,7 @@ public class SimpleCovParser implements CoverageReportParser {
         }
 
         Double covered = extractValueFromPath(content);
-        return covered.floatValue();
+        return covered.floatValue() / 100;
     }
 
     private Double extractValueFromPath(String content) {

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SimpleCovParserTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/SimpleCovParserTest.java
@@ -21,7 +21,7 @@ public class SimpleCovParserTest {
         float coverage = new SimpleCovParser().get(filePath);
 
         // won't be an exact match as we're converting double to float
-        assertThat((double) coverage, is(closeTo(85.7142857142857, 0.00001)));
+        assertThat((double) coverage, is(closeTo(0.857142857142857, 0.00001)));
 
     }
 


### PR DESCRIPTION
It seems that coverage rate in pr message from SimpleCov reporter is 100 times.
I suppose that it should return value divided by 100 along with other reporter values.