### PR TITLE
Support configurable metrics for Jacoco and SonarQube...

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -77,6 +77,10 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         return DESCRIPTOR.isUseSonarForMasterCoverage();
     }
 
+    public static String getSonarCoverageMetric() {
+      return DESCRIPTOR.getSonarCoverageMetric();
+    }
+
     public static void setMasterCoverage(final String repo, final float coverage) {
         DESCRIPTOR.set(repo, coverage);
     }
@@ -104,6 +108,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         private String sonarToken;
         private String sonarLogin;
         private String sonarPassword;
+        private String sonarCoverageMetric;
 
         private int yellowThreshold = DEFAULT_YELLOW_THRESHOLD;
         private int greenThreshold = DEFAULT_GREEN_THRESHOLD;
@@ -184,6 +189,10 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         public String getSonarPassword() {
             return sonarPassword;
         }
+        
+        public String getSonarCoverageMetric() {
+            return sonarCoverageMetric;
+        }
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
@@ -199,6 +208,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             sonarToken = StringUtils.trimToNull(formData.getString("sonarToken"));
             sonarLogin = StringUtils.trimToNull(formData.getString("sonarLogin"));
             sonarPassword = StringUtils.trimToNull(formData.getString("sonarPassword"));
+            sonarCoverageMetric = StringUtils.trimToNull(formData.getString("sonarCoverageMetric"));
             save();
             return super.configure(req, formData);
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
@@ -21,4 +21,6 @@ interface SettingsRepository {
     String getSonarUrl();
 
     String getSonarToken();
+
+    String getSonarCoverageMetric();
 }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
@@ -40,7 +40,9 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
 
     private static final String SONAR_SEARCH_PROJECTS_API_PATH = "/api/projects/index";
     private static final String SONAR_COMPONENT_MEASURE_API_PATH = "/api/measures/component";
-    public static final String SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME = "coverage";
+    public static final String SONAR_OVERALL_INSTRUCTION_COVERAGE_METRIC_NAME = "coverage";
+    public static final String SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME = "line_coverage";
+    public static final String SONAR_OVERALL_BRANCH_COVERAGE_METRIC_NAME = "branch_coverage";
 
     private final String sonarUrl;
     private final String login;
@@ -107,7 +109,10 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
      * @throws SonarCoverageMeasureRetrievalException if an error occurred during retrieval of the coverage
      */
     private float getCoverageMeasure(SonarProject project) throws SonarCoverageMeasureRetrievalException {
-        final String uri = MessageFormat.format("{0}{1}?componentKey={2}&metricKeys={3}", sonarUrl, SONAR_COMPONENT_MEASURE_API_PATH, URLEncoder.encode(project.getKey()), SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME);
+        final SettingsRepository settingsRepository = ServiceRegistry.getSettingsRepository();
+        String metricName = settingsRepository.getSonarCoverageMetric();
+        if (metricName == null) metricName = SONAR_OVERALL_INSTRUCTION_COVERAGE_METRIC_NAME;
+        final String uri = MessageFormat.format("{0}{1}?componentKey={2}&metricKeys={3}", sonarUrl, SONAR_COMPONENT_MEASURE_API_PATH, URLEncoder.encode(project.getKey()), metricName);
         try {
             final GetMethod method = executeGetRequest(uri);
             String value = JsonUtils.findInJson(method.getResponseBodyAsString(), "component.measures[0].value");

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
@@ -48,6 +48,10 @@ f.section(title: descriptor.displayName) {
         f.password()
     }
 
+    f.entry(field: "sonarCoverageMetric", title: _("Sonar coverage metric")) {
+        f.password()
+    }
+
     f.entry(field: "disableSimpleCov", title: _("Disable SimpleCov coverage parser")) {
         f.checkbox()
     }

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/help-sonarCoverageMetric.html
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/help-sonarCoverageMetric.html
@@ -1,0 +1,3 @@
+<div>
+    Coverage metric to retrieve from Sonar(Optional).  It will use &quot;coverage&quot; if not specified.  Known values are &quot;coverage&quot;, &quot;line_coverage&quot;, and &quot;branch_coverage&quot;.
+</div>

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/JacocoParserTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/JacocoParserTest.java
@@ -18,17 +18,56 @@ limitations under the License.
 package com.github.terma.jenkins.githubprcoveragestatus;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
 public class JacocoParserTest {
 
+    private SettingsRepository settingsRepository = mock(SettingsRepository.class);
+    
+    @Before
+    public void initMocks() throws IOException {
+        ServiceRegistry.setSettingsRepository(settingsRepository);
+    }
+    
     @Test
-    public void extractCoverageFromJacocoReport() throws IOException {
+    public void extractCoverageFromJacocoReportDefault() throws IOException {
         String filePath = JacocoParserTest.class.getResource(
                 "/com/github/terma/jenkins/githubprcoveragestatus/JacocoParserTest/jacoco.xml").getFile();
 
+        Mockito.when(settingsRepository.getSonarCoverageMetric()).thenReturn(null);
+        Assert.assertEquals(0.22, new JacocoParser().get(filePath), 0.1);
+    }
+
+    @Test
+    public void extractCoverageFromJacocoReportInstruction() throws IOException {
+        String filePath = JacocoParserTest.class.getResource(
+                "/com/github/terma/jenkins/githubprcoveragestatus/JacocoParserTest/jacoco.xml").getFile();
+
+        Mockito.when(settingsRepository.getSonarCoverageMetric()).thenReturn(SonarMasterCoverageRepository.SONAR_OVERALL_INSTRUCTION_COVERAGE_METRIC_NAME);
+        Assert.assertEquals(0.22, new JacocoParser().get(filePath), 0.1);
+    }
+
+    @Test
+    public void extractCoverageFromJacocoReportLine() throws IOException {
+        String filePath = JacocoParserTest.class.getResource(
+                "/com/github/terma/jenkins/githubprcoveragestatus/JacocoParserTest/jacoco.xml").getFile();
+
+        Mockito.when(settingsRepository.getSonarCoverageMetric()).thenReturn(SonarMasterCoverageRepository.SONAR_OVERALL_LINE_COVERAGE_METRIC_NAME);
+        Assert.assertEquals(0.22, new JacocoParser().get(filePath), 0.1);
+    }
+
+    @Test
+    public void extractCoverageFromJacocoReportBranch() throws IOException {
+        String filePath = JacocoParserTest.class.getResource(
+                "/com/github/terma/jenkins/githubprcoveragestatus/JacocoParserTest/jacoco.xml").getFile();
+
+        Mockito.when(settingsRepository.getSonarCoverageMetric()).thenReturn(SonarMasterCoverageRepository.SONAR_OVERALL_BRANCH_COVERAGE_METRIC_NAME);
         Assert.assertEquals(0.22, new JacocoParser().get(filePath), 0.1);
     }
 
@@ -59,7 +98,7 @@ public class JacocoParserTest {
                             "        \"report.dtd\">\n" +
                             "<report name=\"GitHub Pull Request Coverage Status\">\n" +
                             "</report>",
-                    messageWithoutAbsolutePath);
+                    messageWithoutAbsolutePath.replace("\r\n", "\n"));
         }
     }
 
@@ -83,7 +122,7 @@ public class JacocoParserTest {
                             "<report name=\"GitHub Pull Request Coverage Status\">\n" +
                             "    <counter type=\"LINE\" missed=\"X\" covered=\"0\"/>\n" +
                             "</report>",
-                    messageWithoutAbsolutePath);
+                    messageWithoutAbsolutePath.replace("\r\n", "\n"));
         }
     }
 
@@ -107,7 +146,7 @@ public class JacocoParserTest {
                             "<report name=\"GitHub Pull Request Coverage Status\">\n" +
                             "    <counter type=\"LINE\" missed=\"0\" covered=\"X\"/>\n" +
                             "</report>",
-                    messageWithoutAbsolutePath);
+                    messageWithoutAbsolutePath.replace("\r\n", "\n"));
         }
     }
 

--- a/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/measureFoundBranch.json
+++ b/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/measureFoundBranch.json
@@ -4,7 +4,7 @@
     "key": "my-project:origin/master",
     "measures": [
       {
-        "metric": "coverage",
+        "metric": "branch_coverage",
         "periods": [
           {
             "index": 1,
@@ -19,7 +19,7 @@
             "value": "0.0"
           }
         ],
-        "value": "95.3"
+        "value": "75.3"
       }
     ],
     "name": "my-project origin/master",

--- a/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/measureFoundLine.json
+++ b/src/test/resources/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepositoryTest/measureFoundLine.json
@@ -4,7 +4,7 @@
     "key": "my-project:origin/master",
     "measures": [
       {
-        "metric": "coverage",
+        "metric": "line_coverage",
         "periods": [
           {
             "index": 1,
@@ -19,7 +19,7 @@
             "value": "0.0"
           }
         ],
-        "value": "95.3"
+        "value": "85.2"
       }
     ],
     "name": "my-project origin/master",


### PR DESCRIPTION
Configuration added sonarCoverageMetric parameter.  Known parameters that work are: coverage, branch_coverage, and line_coverage.
I do not have access any Cobertura or Clover envs, so only changed Jacoco to support it for now.