### PR TITLE
Fix how  URL is detected for a PR

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/BuildMasterCoverageRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/BuildMasterCoverageRepository.java
@@ -29,7 +29,9 @@ public class BuildMasterCoverageRepository implements MasterCoverageRepository {
 
     @Override
     public float get(final String gitHubRepoUrl) {
+
         if (gitHubRepoUrl == null) return 0;
+
         final Float coverage = Configuration.DESCRIPTOR.getCoverageByRepo().get(gitHubRepoUrl);
         if (coverage == null) {
             buildLog.println("Can't find master coverage repository: " + gitHubRepoUrl

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
@@ -103,12 +103,25 @@ public class CompareCoverageAction extends Recorder implements SimpleBuildStep {
         final SettingsRepository settingsRepository = ServiceRegistry.getSettingsRepository();
 
         final int prId = PrIdAndUrlUtils.getPrId(scmVars, build, listener);
-        final String gitUrl = PrIdAndUrlUtils.getGitUrl(scmVars, build, listener);
 
+        buildLog.println(BUILD_LOG_PREFIX + "scmVars: " + scmVars);
+
+        final String gitUrl = PrIdAndUrlUtils.getGitUrl(scmVars, build, listener);
+        buildLog.println(BUILD_LOG_PREFIX + "gitUrl: " + gitUrl);
         buildLog.println(BUILD_LOG_PREFIX + "getting master coverage...");
         MasterCoverageRepository masterCoverageRepository = ServiceRegistry.getMasterCoverageRepository(buildLog, sonarLogin, sonarPassword);
         final GHRepository gitHubRepository = ServiceRegistry.getPullRequestRepository().getGitHubRepository(gitUrl);
-        final float masterCoverage = masterCoverageRepository.get(gitUrl);
+        float masterCoverage;
+        if (gitUrl.contains("pull/")) {
+            final String myCorrectURL = "https://github.com/" + GitUtils.getUserRepo(gitUrl);
+            // Using  masterCoverageRepository.get(myCorrectURL); is failing because URL is
+            // https://github.com/USER/REPO/pull/PR_ID
+            buildLog.println(BUILD_LOG_PREFIX + "myCorrectURL:" + myCorrectURL);
+            masterCoverage = masterCoverageRepository.get(myCorrectURL);
+        } else {
+            masterCoverage = masterCoverageRepository.get(gitUrl);
+        }
+
         buildLog.println(BUILD_LOG_PREFIX + "master coverage: " + masterCoverage);
 
         buildLog.println(BUILD_LOG_PREFIX + "collecting coverage...");

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/PrIdAndUrlUtils.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/PrIdAndUrlUtils.java
@@ -76,14 +76,24 @@ public class PrIdAndUrlUtils {
     }
 
     public static String getGitUrl(final Map<String, String> scmVars, final Run build, final TaskListener listener) throws IOException, InterruptedException {
+        final PrintStream buildLog = listener.getLogger();
         Map<String, String> envVars = build.getEnvironment(listener);
         final String gitUrl = envVars.get(GIT_URL_PROPERTY);
         final String changeUrl = envVars.get(CHANGE_URL_PROPERTY);
-        if (gitUrl != null) return gitUrl;
-        else if (changeUrl != null) return changeUrl;
-        else if (scmVars != null && scmVars.containsKey(GIT_URL_PROPERTY)) return scmVars.get(GIT_URL_PROPERTY);
-        else throw new UnsupportedOperationException("Can't find " + GIT_URL_PROPERTY
+        if (gitUrl != null) {
+            buildLog.println("gitUrl :" + gitUrl);
+            return gitUrl;
+        }
+        else if (changeUrl != null) {
+            return changeUrl;
+        }
+        else if (scmVars != null && scmVars.containsKey(GIT_URL_PROPERTY)) {
+            //buildLog.println("Found scmVars :" + gitUrl);
+            return scmVars.get(GIT_URL_PROPERTY);
+        } else {
+            throw new UnsupportedOperationException("Can't find " + GIT_URL_PROPERTY
                     + " or " + CHANGE_URL_PROPERTY + " in envs: " + envVars);
+        }
     }
 
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/GitUtilsTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/GitUtilsTest.java
@@ -39,6 +39,7 @@ public class GitUtilsTest {
                 GitUtils.getUserRepo("git@github.com:terma/jenkins-github-coverage-updater"));
     }
 
+
     @Test
     public void getRepoName() {
         Assert.assertEquals(


### PR DESCRIPTION
 This mostly boils down to removing PULL/ID from USER/REPO/PULL/ID.

 All the other changes are debugging messages so it's easier to follow
 the logic.

 This a possible fix for #39 and #42

My pipeline now contains the following statements:

```


...
currentBuild.result = 'SUCCESS'
                  try {
                      echo "In PR"
                      step([$class: 'CompareCoverageAction', scmVars: [GIT_URL: "https://github.com/mobilityhouse/testci",])
                  } catch (error) {
                    echo "Not in PR"
                    echo error.getMessage()
                  }



 post {
        success {
           script {
              if (env.BRANCH_NAME == 'master') {
              step([$class: 'MasterCoverageAction',
                  scmVars:
                    [GIT_URL: "https://github.com/mobilityhouse/testci",]
                   ])
              echo 'hura!'
              }
           }
        }


```