### PR TITLE
Update GitHub api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.71</version>
+            <version>1.90</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,8 @@
     </issueManagement>
 
     <properties>
-        <jenkins.version>1.580.1</jenkins.version>
-        <!--<jenkins.version>2.46.3</jenkins.version>-->
-        <java.level>6</java.level>
-        <!--<java.level>7</java.level>-->
+        <jenkins.version>2.7</jenkins.version>
+        <java.level>7</java.level>
     </properties>
 
     <repositories>


### PR DESCRIPTION
The `github-api` currently used by the plugin is quite old (2015) and does not include a bunch of fixes that have been included in that library (some of them fix bugs that I'm hitting through the code coverage plugin!).

This PR updates the dependencies to the same versions that the [github pull request builder plugin uses](https://github.com/jenkinsci/ghprb-plugin/blob/ghprb-1.40.0/pom.xml) on it latest version.