### PR TITLE
Fail build on coverage decrease

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ where first one is Pull Request ID (number) and second link to repository
         }
     }
 ```
+
+### Making the build fail on coverage drop
+
+It is also possible to just make the build fail if the coverage drops instead of commenting on the PR.
+
+The setup is identical apart from the arguments into the `CompareCoverageAction` you have to pass an additional
+`failBuildOnConverageDecrease: true` into the step.
+
+
 ## Troubleshooting
 
 ### No coverage picture and my Jenkins is in private network and not accessible for GitHub

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -120,4 +120,35 @@ public class CompareCoverageActionTest {
         verify(pullRequestRepository).comment(ghRepository, 12, "[![0% (0.0%) vs master 0%](customJ/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
     }
 
+    @Test
+    public void doNotCommentButFailBuildIfConfiguredToDoSo() throws IOException, InterruptedException {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getEnvironment(any(TaskListener.class))).thenReturn(envVars);
+        when(envVars.get(PrIdAndUrlUtils.GIT_PR_ID_ENV_PROPERTY)).thenReturn("12");
+        when(envVars.get(Utils.BUILD_URL_ENV_PROPERTY)).thenReturn("aaa/job/a");
+        when(listener.error(anyString())).thenReturn(printWriter);
+        when(masterCoverageRepository.get(anyString())).thenReturn(0.999f);
+
+        CompareCoverageAction underTest = new CompareCoverageAction();
+        underTest.setFailBuildOnConverageDecrease(true);
+        underTest.perform(build, null, null, listener);
+
+        verify(build, atLeastOnce()).setResult(Result.FAILURE);
+    }
+
+    @Test
+    public void doNotCommentButPassBuildIfConfiguredToDoSo() throws IOException, InterruptedException {
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getEnvironment(any(TaskListener.class))).thenReturn(envVars);
+        when(envVars.get(PrIdAndUrlUtils.GIT_PR_ID_ENV_PROPERTY)).thenReturn("12");
+        when(envVars.get(Utils.BUILD_URL_ENV_PROPERTY)).thenReturn("aaa/job/a");
+        when(listener.error(anyString())).thenReturn(printWriter);
+
+        CompareCoverageAction underTest = new CompareCoverageAction();
+        underTest.setFailBuildOnConverageDecrease(true);
+        underTest.perform(build, null, null, listener);
+
+        verify(build, never()).setResult(Result.FAILURE);
+    }
+
 }


### PR DESCRIPTION
This change introduces another boolean flag to the compare action - which instead of commenting on the PR will simply fail the build if the coverage decreases, e.g.

```
step([$class: 'CompareCoverageAction', scmVars: [GIT_URL: env.GIT_URL], failBuildOnConverageDecrease: true ])

```


