### PR TITLE
[INFRA-1851] Enable tlsv1.2 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-buildPlugin(platforms: ['linux'], jdkVersions: [7, 8], findbugs: [archive: true, unstableTotalAll: '0'], checkstyle: [run: true, archive: true])
+buildPlugin(platforms: ['linux'], jdkVersions: [8], findbugs: [archive: true, unstableTotalAll: '0'], checkstyle: [run: true, archive: true])
 
 //node {
 //    stage 'post-build'

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
     </issueManagement>
 
     <properties>
+        <!--Enable TLSv1.2 as older version are not supported anymore -->
+        <https.protocols>TLSv1.2</https.protocols>
         <jenkins.version>1.580.1</jenkins.version>
         <!--<jenkins.version>2.46.3</jenkins.version>-->
         <java.level>6</java.level>


### PR DESCRIPTION
This PR is an attempt to fix:
```
08:49:17 [linux-7] [ERROR]     Non-resolvable parent POM for org.jenkins-ci.plugins:github-pr-coverage-status:1.10.1-SNAPSHOT: Could not transfer artifact org.jenkins-ci.plugins:plugin:pom:2.11 from/to repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/): Received fatal alert: protocol_version and 'parent.relativePath' points at no local POM @ line 3, column 13 -> [Help 2]
08:49:17 [linux-7] org.apache.maven.model.resolution.UnresolvableModelException: Could not transfer artifact org.jenkins-ci.plugins:plugin:pom:2.11 from/to repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/): Received fatal alert: protocol_version
```

https://repo.jenkins-ci.org only support TLSv1.2