### PR TITLE
Fail the status check when the coverage decreased

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
@@ -198,7 +198,7 @@ public class CompareCoverageAction extends Recorder implements SimpleBuildStep {
             ServiceRegistry.getPullRequestRepository().createCommitStatus(
                     gitHubRepository,
                     commits.get(commits.size() - 1).getSha(),
-                    GHCommitState.SUCCESS,
+                    coverage < targetCoverage ? GHCommitState.FAILURE : GHCommitState.SUCCESS,
                     buildUrl,
                     message.forStatusCheck()
             );

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/GitHubPullRequestRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/GitHubPullRequestRepository.java
@@ -90,6 +90,6 @@ public class GitHubPullRequestRepository implements PullRequestRepository {
             String targetUrl,
             String description
     ) throws IOException {
-        ghRepository.createCommitStatus(sha1, GHCommitState.SUCCESS, targetUrl, description, "test-coverage-plugin");
+        ghRepository.createCommitStatus(sha1, state, targetUrl, description, "test-coverage-plugin");
     }
 }

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -86,7 +86,7 @@ public class CompareCoverageActionTest {
 
         verify(pullRequestRepository).comment(ghRepository, 12, "[![0% (0.0%) vs master 0%](aaa/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
     }
-    
+
     @Test
     public void postResultAsStatusCheck() throws IOException, InterruptedException {
         prepareBuildSuccess();

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -27,7 +27,6 @@ import org.kohsuke.github.*;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -163,7 +162,6 @@ public class CompareCoverageActionTest {
     }
     
     private void prepareCoverageData(float masterCoverage, float prCoverage) throws IOException, InterruptedException {
-        PrintStream logger = mock(PrintStream.class);
         when(masterCoverageRepository.get(GIT_URL)).thenReturn(masterCoverage);
         when(coverageRepository.get(null)).thenReturn(prCoverage);
         initMocks();

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -94,9 +94,9 @@ public class CompareCoverageActionTest {
         prepareCommit();
         prepareCoverageData(0.88f, 0.95f);
         coverageAction.setPublishResultAs("statusCheck");
-        
+
         coverageAction.perform(build, null, null, listener);
-        
+
         verify(pullRequestRepository).createCommitStatus(
                 ghRepository,
                 "fh3k2l",
@@ -113,9 +113,9 @@ public class CompareCoverageActionTest {
         prepareCommit();
         prepareCoverageData(0.95f, 0.9f);
         coverageAction.setPublishResultAs("statusCheck");
-        
+
         coverageAction.perform(build, null, null, listener);
-        
+
         verify(pullRequestRepository).createCommitStatus(
                 ghRepository,
                 "fh3k2l",

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -32,8 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
-import com.github.terma.jenkins.githubprcoveragestatus.MasterCoverageRepository;
-import com.github.terma.jenkins.githubprcoveragestatus.CoverageRepository;
 
 public class CompareCoverageActionTest {
 

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -94,7 +94,9 @@ public class CompareCoverageActionTest {
         prepareCommit();
         prepareCoverageData(0.88f, 0.95f);
         coverageAction.setPublishResultAs("statusCheck");
+        
         coverageAction.perform(build, null, null, listener);
+        
         verify(pullRequestRepository).createCommitStatus(
                 ghRepository,
                 "fh3k2l",
@@ -111,7 +113,9 @@ public class CompareCoverageActionTest {
         prepareCommit();
         prepareCoverageData(0.95f, 0.9f);
         coverageAction.setPublishResultAs("statusCheck");
+        
         coverageAction.perform(build, null, null, listener);
+        
         verify(pullRequestRepository).createCommitStatus(
                 ghRepository,
                 "fh3k2l",

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -86,6 +86,24 @@ public class CompareCoverageActionTest {
 
         verify(pullRequestRepository).comment(ghRepository, 12, "[![0% (0.0%) vs master 0%](aaa/coverage-status-icon/?coverage=0.0&masterCoverage=0.0)](aaa/job/a)");
     }
+    
+    @Test
+    public void postResultAsStatusCheck() throws IOException, InterruptedException {
+        prepareBuildSuccess();
+        prepareEnvVars();
+        prepareCommit();
+        coverageAction.setPublishResultAs("statusCheck");
+
+        coverageAction.perform(build, null, null, listener);
+
+        verify(pullRequestRepository).createCommitStatus(
+                ghRepository,
+                "fh3k2l",
+                GHCommitState.SUCCESS,
+                "aaa/job/a",
+                "Coverage 0% changed 0.0% vs master 0%"
+        );
+    }
 
     @Test
     public void postResultAsSuccessfulStatusCheck() throws IOException, InterruptedException {


### PR DESCRIPTION
This is feature is essential for enforcing the code coverage, using GH status and branch protection.