### PR TITLE
Remove unneeded buildPlugin configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-buildPlugin(platforms: ['linux'], findbugs: [archive: true, unstableTotalAll: '0'], checkstyle: [run: true, archive: true])
+buildPlugin(platforms: ['linux'])
 
 //node {
 //    stage 'post-build'


### PR DESCRIPTION
Checkstyle and spotbugs are being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, (assuming that checkstyle is bound to a phase in the build directly, the task is no longer directly invoked)