### PR TITLE
Add support for coverage thresholds and tolerance of minor drops in coverage in Github status checks

### DIFF
--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -65,6 +65,10 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         return DESCRIPTOR.getSonarToken();
     }
 
+    public static String getTolerance() {
+        return Float.toString(DESCRIPTOR.getTolerance());
+    }
+
     public static String getSonarLogin() {
         return DESCRIPTOR.getSonarLogin();
     }
@@ -91,6 +95,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
 
         private static final int DEFAULT_YELLOW_THRESHOLD = 80;
         private static final int DEFAULT_GREEN_THRESHOLD = 90;
+        private static final float DEFAULT_TOLERANCE = 0;
 
         private final Map<String, Float> coverageByRepo = new ConcurrentHashMap<String, Float>();
 
@@ -107,6 +112,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
 
         private int yellowThreshold = DEFAULT_YELLOW_THRESHOLD;
         private int greenThreshold = DEFAULT_GREEN_THRESHOLD;
+        private float tolerance = DEFAULT_TOLERANCE;
 
         public ConfigurationDescriptor() {
             load();
@@ -145,6 +151,11 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
         @Override
         public int getGreenThreshold() {
             return greenThreshold;
+        }
+
+        @Override
+        public float getTolerance() {
+            return tolerance;
         }
 
         @Override
@@ -191,6 +202,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             personalAccessToken = StringUtils.trimToNull(formData.getString("personalAccessToken"));
             yellowThreshold = NumberUtils.toInt(formData.getString("yellowThreshold"), DEFAULT_YELLOW_THRESHOLD);
             greenThreshold = NumberUtils.toInt(formData.getString("greenThreshold"), DEFAULT_GREEN_THRESHOLD);
+            tolerance = NumberUtils.toFloat(formData.getString("tolerance"), DEFAULT_TOLERANCE);
             jenkinsUrl = StringUtils.trimToNull(formData.getString("jenkinsUrl"));
             privateJenkinsPublicGitHub = BooleanUtils.toBoolean(formData.getString("privateJenkinsPublicGitHub"));
             useSonarForMasterCoverage = BooleanUtils.toBoolean(formData.getString("useSonarForMasterCoverage"));

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Message.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Message.java
@@ -61,10 +61,21 @@ class Message {
     }
 
     public String forStatusCheck() {
-        return String.format("Coverage %s changed %s vs master %s",
+        return forConsole();
+    }
+
+    public String forThresholdStatusCheck(final int greenThreshold){
+        return String.format("Coverage %s vs threshold %s",
+                Percent.toWholeNoSignString(coverage),
+                Integer.toString(greenThreshold));
+    }
+
+    public String forToleranceStatusCheck(float tolerance){
+        return String.format("Coverage %s changed %s vs master %s (tolerance %s)",
                 Percent.toWholeNoSignString(coverage),
                 Percent.toString(Percent.change(coverage, masterCoverage)),
-                Percent.toWholeNoSignString(masterCoverage));
+                Percent.toWholeNoSignString(masterCoverage),
+                Float.toString(tolerance));
     }
 
     private String shieldIoUrl(String icon, final int yellowThreshold, final int greenThreshold) {

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SettingsRepository.java
@@ -11,6 +11,8 @@ interface SettingsRepository {
     int getYellowThreshold();
 
     int getGreenThreshold();
+    
+    float getTolerance();
 
     boolean isPrivateJenkinsPublicGitHub();
 

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction/config.jelly
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction/config.jelly
@@ -15,4 +15,11 @@
             <f:option value="statusCheck">${%Status Check}</f:option>
           </select>
         </f:entry>
+        <f:entry title="${%Mode of comparing against master}" field="comparisonMode">
+          <select name="comparisonMode">
+            <f:option value="Strict">${%Strict}</f:option>
+            <f:option value="threshold">${%Threshold}</f:option>
+            <f:option value="tolerance">${%Tolerance}</f:option>
+          </select>
+        </f:entry>
 </j:jelly>

--- a/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
+++ b/src/main/resources/com/github/terma/jenkins/githubprcoveragestatus/Configuration/global.groovy
@@ -27,6 +27,10 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "greenThreshold", title: _("Green Threshold 0-100%")) {
         f.textbox()
     }
+    
+    f.entry(field: "tolerance", title: _("Tolerance for comparing to master 0.0-1.0")) {
+        f.textbox()
+    }
 
     f.entry(field: "useSonarForMasterCoverage", title: _("Use Sonar for master coverage")) {
         f.checkbox()


### PR DESCRIPTION
This pull request adds two new features which are adding support for Github status checks with the defined coverage threshold as well as a tolerance option to address minor drops in code coverage which can fail a build outlined in issue #84. 

Here are some screenshots of the default behavior as well as demonstrations of each of these two features passing and failing a build.

Default:
![Normal_Result](https://user-images.githubusercontent.com/1399153/90776692-6d1a5400-e2c8-11ea-9c8b-80e35e95fcca.png)

Thresholds:
![Failing_Threshold](https://user-images.githubusercontent.com/1399153/90776690-6c81bd80-e2c8-11ea-9315-d7e29be3333f.png)
![Passing_Threshold](https://user-images.githubusercontent.com/1399153/90776695-6db2ea80-e2c8-11ea-8e69-482eb4406325.png)

Tolerance:
![Failing_Tolerance](https://user-images.githubusercontent.com/1399153/90776691-6d1a5400-e2c8-11ea-8af8-8244bf2f4cd6.png)
![Passing_Tolerance](https://user-images.githubusercontent.com/1399153/90776698-6db2ea80-e2c8-11ea-8431-3dc46d7dcf21.png)
