### PR TITLE
Refresh plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.32</version>
+        <version>4.49</version>
         <relativePath />
     </parent>
 
     <artifactId>github-pr-coverage-status</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
 
-    <url>https://github.com/jenkinsci/github-pr-coverage-status-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <name>GitHub Pull Request Coverage Status</name>
 
@@ -50,8 +51,10 @@
     </issueManagement>
 
     <properties>
-        <jenkins.version>2.7</jenkins.version>
-        <java.level>8</java.level>
+        <revision>2.2.0</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.319.1</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
     <repositories>
@@ -72,100 +75,39 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-httpclient3-api</artifactId>
+            <version>3.1-3</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.90</version>
+            <version>1.303-400.v35c2d8258028</version>
         </dependency>
 
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.2.0</version>
+            <version>2.7.0</version>
+            <exclusions>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.20.0</version>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>2.28.1</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-util</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-http</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-webapp</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-servlet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-release-plugin</artifactId>-->
-                <!--<version>2.5.1</version>-->
-                <!--<configuration>-->
-                    <!--<autoVersionSubmodules>true</autoVersionSubmodules>-->
-                    <!--<preparationGoals>clean package</preparationGoals>-->
-                    <!--<completionGoals>release:clean</completionGoals>-->
-                    <!--<resume>false</resume>-->
-                    <!--<useReleaseProfile>true</useReleaseProfile>-->
-                    <!--<releaseProfiles>nexus</releaseProfiles>-->
-                    <!--<goals>package</goals>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageAction.java
@@ -35,7 +35,7 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -217,7 +217,7 @@ public class CompareCoverageAction extends Recorder implements SimpleBuildStep {
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Publish coverage to GitHub";
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/Configuration.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -117,7 +117,7 @@ public class Configuration extends AbstractDescribableImpl<Configuration> {
             return "Coverage status for GitHub Pull Requests";
         }
 
-        @Nonnull
+        @NonNull
         public Map<String, Float> getCoverageByRepo() {
             return coverageByRepo;
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/MasterCoverageAction.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/MasterCoverageAction.java
@@ -32,7 +32,7 @@ import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Map;
@@ -104,7 +104,7 @@ public class MasterCoverageAction extends Recorder implements SimpleBuildStep {
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return DISPLAY_NAME;
         }

--- a/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
+++ b/src/main/java/com/github/terma/jenkins/githubprcoveragestatus/SonarMasterCoverageRepository.java
@@ -111,7 +111,7 @@ public class SonarMasterCoverageRepository implements MasterCoverageRepository {
         try {
             final GetMethod method = executeGetRequest(uri);
             String value = JsonUtils.findInJson(method.getResponseBodyAsString(), "component.measures[0].value");
-            return Float.valueOf(value) / 100;
+            return Float.parseFloat(value) / 100;
         } catch (Exception e) {
             throw new SonarCoverageMeasureRetrievalException(String.format("failed to get coverage measure for sonar project %s - %s", project.getKey(), e.getMessage()), e);
         }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Addon for <a href="https://plugins.jenkins.io/ghprb/">GitHub Pull Request Builder</a> gives you the possibility of publishing code coverage status (Cobertura and Jenkins) to Pull Request Commits.
+    You will see coverage of your PR and comparison with the main branch.
+</div>

--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/PrIdAndUrlUtilsTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/PrIdAndUrlUtilsTest.java
@@ -30,7 +30,7 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
This plugin currently consumes the deprecated Commons HttpClient 3.x API via Jenkins core. In https://github.com/jenkinsci/jenkins/pull/7312 we plan to remove this library from Jenkins core. To ensure this plugin continues to work, this PR prepares the plugin for https://github.com/jenkinsci/jenkins/pull/7312 by adding a dependency on the [Commons HttpClient 3.x API plugin](https://plugins.jenkins.io/commons-httpclient3-api/). While we were here, we refreshed the build toolchain and dependencies to recent versions. CC @dmotpan