### PR TITLE
Resolved mismatch stubbings in CompareCoverageActionTest.java

### DIFF
--- a/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
+++ b/src/test/java/com/github/terma/jenkins/githubprcoveragestatus/CompareCoverageActionTest.java
@@ -208,5 +208,7 @@ public class CompareCoverageActionTest {
         when(envVars.get(PrIdAndUrlUtils.GIT_PR_ID_ENV_PROPERTY)).thenReturn(prId);
         when(envVars.get(Utils.BUILD_URL_ENV_PROPERTY)).thenReturn(buildUrl);
         when(envVars.get(PrIdAndUrlUtils.GIT_URL_PROPERTY)).thenReturn(GIT_URL);
+        when(envVars.get("CHANGE_ID")).thenReturn(null);
+        when(envVars.get("CHANGE_URL")).thenReturn(null);
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `postCoverageStatusToPullRequestAsComment`, `postResultAsStatusCheck`, `postResultAsSuccessfulStatusCheck`, `postResultAsFailedStatusCheck`, `keepBuildGreenAndLogErrorIfExceptionDuringGitHubAccess`,  `postCoverageStatusToPullRequestAsCommentWithShieldIoIfPrivateJenkinsPublicGitHubTurnOn` and `postCoverageStatusToPullRequestAsCommentWithCustomJenkinsUrlIfConfigured`, 

* The `get` method for the `envVars` object:
i) is stubbed in the `prepareEnvVars` method
ii) during test execution the method is actually called with argument `"CHANGE_ID"`, but is not stubbed, resulting in a mismatch stubbing
iii) during test execution the method is actually called with argument `"CHANGE_URL"`, but is not stubbed, resulting in another mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch! 
- [ ] Ensure that the pull request title represents the desired changelog entry (Not applicable)
- [x] Please describe what you did 
- [ ] Link to relevant issues in GitHub or Jira (Not applicable)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes (Not applicable)
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed (Not applicable)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
